### PR TITLE
:sparkles: Add Home Assistant

### DIFF
--- a/.envrc.tpl
+++ b/.envrc.tpl
@@ -47,6 +47,7 @@ export DOMAIN_PORTAINER=portainer.${DOMAIN_VNET}
 export DOMAIN_UNIFI_CONTROLLER=unifi.${DOMAIN_VNET}
 export DOMAIN_JELLYFIN=video.${DOMAIN_VNET}
 export DOMAIN_KOLIBRI=edu.${DOMAIN_VNET}
+export DOMAIN_HOMEASSISTANT=homeassistant.${DOMAIN_VNET}
 export KIWIX_DATA_DIR=${PROJECT_ROOT}/config/services/kiwix/data
 export TRANSMISSION_CONFIG_DIR=${PROJECT_ROOT}/config/services/transmission/config
 export TRANSMISSION_DOWNLOADS_DIR=${PROJECT_ROOT}/config/services/transmission/downloads

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ volumes:
     name: kolibri
   jellyfin:
     name: jellyfin
+  homeassistant:
+    name: homeassistant
 
 services:
   grafana:
@@ -363,3 +365,19 @@ services:
       traefik.http.services.kolibri.loadbalancer.server.port: 8080
     networks:
       - traefik
+
+  homeassistant:
+    image: homeassistant/home-assistant
+    container_name: homeassistant
+    restart: unless-stopped
+    environment:
+      TZ: ${TZ}
+    volumes:
+      - homeassistant:/config
+    labels:
+      - traefik.enable: "true"
+      - traefik.http.routers.homeassistant.entrypoints: websecure
+      - traefik.http.routers.homeassistant.rule: Host(`${DOMAIN_HOMEASSISTANT}`)
+      - traefik.http.routers.homeassistant.tls: "true"
+      - traefik.http.services.homeassistant.loadbalancer.server.port: 8123
+


### PR DESCRIPTION
This PR adds Home Assistant to the Lokal stack of services.

Notes:
- Official Docs recommend running in privileged mode (it appears to facilitate the opening of serial ports for Z-Wave devices etc) which I have not done as it removes the benefits of running in a containerized environment.
- Official Docs recommend running in host networking mode, which is not implemented here.